### PR TITLE
fix(a11y): reduced-motion 카메라 목표값 동기화

### DIFF
--- a/src/components/three/controllers/CameraController.tsx
+++ b/src/components/three/controllers/CameraController.tsx
@@ -14,7 +14,7 @@ export const CameraController = () => {
   const introTargetYRef = useRef<number | null>(null);
   const suspendScrollLookAtRef = useRef(false);
   const reframeSequenceRef = useRef(0);
-  const releaseIntroTargetRef = useRef(false);
+  const introTargetReleaseFramesRef = useRef(0);
   const previousNarrowViewportRef = useRef(isNarrowViewport);
   const previousReducedMotionRef = useRef(prefersReducedMotion);
   const introVectors = useMemo(
@@ -62,7 +62,12 @@ export const CameraController = () => {
     controls.getTarget(introVectors.target);
 
     introElapsed.current = 2;
-    introTargetYRef.current = null;
+    introTargetYRef.current = shouldCompleteIntro
+      ? introVectors.endTarget.y
+      : null;
+    // The camera frame runs before the scroll-control frame. Keep the final
+    // target through one full frame so the scroll controller can sync to it.
+    introTargetReleaseFramesRef.current = shouldCompleteIntro ? 2 : 0;
     suspendScrollLookAtRef.current = true;
     const reframeSequence = reframeSequenceRef.current + 1;
     reframeSequenceRef.current = reframeSequence;
@@ -88,9 +93,11 @@ export const CameraController = () => {
   useFrame((_, delta) => {
     if (!controlsRef.current) return;
 
-    if (releaseIntroTargetRef.current) {
-      releaseIntroTargetRef.current = false;
-      introTargetYRef.current = null;
+    if (introTargetReleaseFramesRef.current > 0) {
+      introTargetReleaseFramesRef.current -= 1;
+      if (introTargetReleaseFramesRef.current === 0) {
+        introTargetYRef.current = null;
+      }
     }
 
     const duration = 2;
@@ -99,7 +106,7 @@ export const CameraController = () => {
     if (prefersReducedMotion) {
       introElapsed.current = duration;
       introTargetYRef.current = introVectors.endTarget.y;
-      releaseIntroTargetRef.current = true;
+      introTargetReleaseFramesRef.current = 1;
       controlsRef.current.setLookAt(
         introVectors.endPos.x,
         introVectors.endPos.y,


### PR DESCRIPTION
## 목적

PR #230 병합 후 발견된 P1 리뷰를 대응합니다. 인트로 진행 중 `prefers-reduced-motion`이 활성화되면 카메라는 최종 Y로 이동하지만, 스크롤 제어 훅의 내부 목표값이 이전 인트로 프레임에 남아 자동 움직임이 다시 발생할 수 있었습니다.

## 변경점

- 동적 reduced-motion 전환 시 최종 카메라 Y를 `introTargetYRef`에 유지
- 카메라 프레임 다음에 실행되는 스크롤 제어 프레임이 목표값을 동기화할 때까지 ref 해제를 지연
- 초기 reduced-motion 경로도 같은 프레임 카운터 방식으로 정리

## 영향

모션 감소 설정을 페이지 로드 중 켜더라도 카메라가 최종 위치에서 다시 움직이지 않습니다. 일반 모션과 휠 제어 동작은 유지됩니다.

## 검증

- `npm ci`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Playwright: 인트로 400ms 시점에 reduced-motion 동적 활성화 후 0.7초 간격 canvas 3회 캡처가 바이트 단위로 동일
- 대조군: no-preference 상태에서는 같은 간격의 canvas가 변경됨

## 관련 리뷰

- #230 `PRRT_kwDOOM0urc6UPpjJ`