### PR TITLE
fix: 헤더 배경을 전체 폭으로 확장

### DIFF
--- a/src/portfolio/portfolio.css
+++ b/src/portfolio/portfolio.css
@@ -146,9 +146,10 @@
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  width: min(100% - 2rem, 86rem);
+  width: 100%;
   min-height: 5.25rem;
-  margin: 0 auto;
+  margin: 0;
+  padding-inline: max(1rem, calc((100% - 86rem) / 2));
   border-bottom: 1px solid var(--page-line);
   background: var(--page-header);
   backdrop-filter: blur(18px) saturate(120%);
@@ -1360,8 +1361,9 @@
 
 @media (max-width: 700px) {
   .site-header {
-    width: min(100% - 1.5rem, 86rem);
+    width: 100%;
     min-height: 4.6rem;
+    padding-inline: 0.75rem;
   }
 
   .site-brand__copy span {


### PR DESCRIPTION
## 목적

데스크톱에서 페이지를 스크롤했을 때 sticky 헤더가 중앙의 네모난 박스로 보이는 경계를 제거합니다.

## 원인

`.site-header` 자체에 중앙 제한 폭(`min(100% - 2rem, 86rem)`)과 불투명 배경·하단선이 함께 적용돼, 넓은 화면에서 헤더 좌우로 페이지 배경이 드러났습니다.

## 변경점

- 헤더 자체 폭을 `100%`로 확장해 배경과 하단선을 화면 전체에 적용했습니다.
- `padding-inline: max(1rem, calc((100% - 86rem) / 2))`로 기존 콘텐츠 최대 폭과 정렬을 그대로 유지했습니다.
- 700px 이하에서는 `padding-inline: 0.75rem`을 적용해 기존 모바일 내부 폭을 유지했습니다.
- DOM, sticky 위치, z-index, 내비게이션 구조는 변경하지 않았습니다.

## 검증 방법

- `npm run lint`
- `npm run typecheck`
- `npm run test:portfolio`
- `npm run build`
- `git diff --check`
- 1920·1440·1280·901·900·701·700·390px에서 header/client 폭, 콘텐츠 정렬, 메뉴 겹침, 가로 오버플로 확인
- 브랜드·내비게이션·테마·3D Lab hit-test 확인
- 테마 전환 및 `/?view=3d` 실제 이동 확인
- 독립 Red Team 검토: P0~P2 0건

## 시각적 변경

시각 자료 없음 — 인앱 브라우저의 화면 캡처 명령이 운영·로컬 양쪽에서 시간 초과됐습니다. 대신 동일 뷰포트의 실제 DOM 기하를 비교했습니다.

| 조건 | 변경 전 | 변경 후 | 판단 포인트 |
| --- | --- | --- | --- |
| 1440px 창 (`clientWidth 1425px`) | header `x=24.5`, `width=1376` | header `x=0`, `width=1425`, padding `24.5px` | 배경·하단선은 전체 폭, 브랜드 시작점은 동일 |
| 1920px 창 | 중앙 제한 폭 배경 | header `width=clientWidth`, 콘텐츠 `86rem` | 넓은 화면의 좌우 경계 제거 |
| 390px 창 | 내부 폭 `viewport - 24px` | header `100%`, padding `12px` | 기존 모바일 정렬 유지, 가로 넘침 없음 |

## 리스크

- CSS 1개 파일의 폭·여백 처리만 변경했습니다.
- `100vw`를 사용하지 않아 세로 스크롤바로 인한 가로 오버플로를 피했습니다.
- 기존 3D 청크 크기 경고는 lazy-load 상태로 유지되며 이번 변경과 무관합니다.

## 판단

**Recommend** — 요청한 경계를 제거하면서 기존 콘텐츠 폭과 반응형 동작을 보존했습니다.