### PR TITLE
fix: 공개 프로젝트 구현 범위 분량 조정

### DIFF
--- a/scripts/validate-portfolio-content.mjs
+++ b/scripts/validate-portfolio-content.mjs
@@ -266,13 +266,15 @@ for (const [label, surface, approvedCopy] of [
   [
     "portfolioContent.ts",
     content,
-    "W/E/R 변환 모드는 뷰포트 또는 트랜스폼 도구에 포커스가 있을 때만 동작합니다.",
+    "단축키는 뷰포트·변환 도구에 포커스가 있을 때만 작동하고",
   ],
-  ["portfolioContent.ts", content, "Ctrl/⌘+Shift+Z 또는 Ctrl/⌘+Y 다시 실행"],
+  ["portfolioContent.ts", content, "텍스트 입력·IME 중에는 가로채지 않습니다."],
+  ["portfolioContent.ts", content, "장면은 IndexedDB에 저장합니다."],
+  ["portfolioContent.ts", content, "협업 서버는 로컬 개발용"],
   [
     "portfolioContent.ts",
     content,
-    "입력 필드·편집 영역·IME 조합 중·키 반복에는 편집 단축키를 가로채지 않습니다.",
+    "운영 인증·권한·서버 저장은 제공하지 않습니다.",
   ],
   [
     "portfolioContent.ts",
@@ -342,6 +344,11 @@ for (const [label, surface, replacedCopy] of [
   ],
   ["portfolioContent.ts", content, "AI experiment"],
   ["portfolioContent.ts", content, "LocalMesh Studio의 3D 편집 화면"],
+  [
+    "portfolioContent.ts",
+    content,
+    "Esc 선택·드래그 취소, Delete/Backspace 삭제",
+  ],
   ["README.md", readme, "3D 경험 보존"],
 ]) {
   assertExcludes(surface, replacedCopy, label);

--- a/src/portfolio/portfolioContent.ts
+++ b/src/portfolio/portfolioContent.ts
@@ -102,7 +102,7 @@ export const publicProjects: readonly PublicProject[] = [
     description:
       "오브젝트 선택·강조, 이동·회전·크기 기즈모, W/E/R·Esc·Delete/Backspace·Undo/Redo 단축키를 SceneCommand·Yjs 기반 편집 흐름에 연결한 local-first 3D Studio입니다. 기즈모 드래그는 변경 축만 기록해 서로 다른 축의 동시 편집을 보존하고, 로컬 LLM 명령은 스키마 검증과 사용자 승인 뒤 적용되며 장면은 브라우저에 저장됩니다.",
     boundary:
-      "W/E/R 변환 모드는 뷰포트 또는 트랜스폼 도구에 포커스가 있을 때만 동작합니다. Esc 선택·드래그 취소, Delete/Backspace 삭제, Ctrl/⌘+Z 실행 취소, Ctrl/⌘+Shift+Z 또는 Ctrl/⌘+Y 다시 실행도 지원하며, 입력 필드·편집 영역·IME 조합 중·키 반복에는 편집 단축키를 가로채지 않습니다. 공개 데모는 IndexedDB에 저장하는 로컬 모드이며, 협업 서버는 로컬 개발용이라 운영 환경에 필요한 인증, 접근 제어, 서버 저장 기능은 포함하지 않았습니다.",
+      "단축키는 뷰포트·변환 도구에 포커스가 있을 때만 작동하고, 텍스트 입력·IME 중에는 가로채지 않습니다. 장면은 IndexedDB에 저장합니다. 협업 서버는 로컬 개발용이며, 운영 인증·권한·서버 저장은 제공하지 않습니다.",
     image:
       "https://raw.githubusercontent.com/okorion/localmesh-studio/main/public/og.png",
     imageAlt:


### PR DESCRIPTION
## 목적

공개 프로젝트 카드의 `현재 구현 범위` 분량을 맞추고, LocalMesh 카드의 중복된 단축키 설명을 줄입니다.

## 변경점

- LocalMesh 구현 범위를 277자에서 124자로 축약했습니다.
- 상세 키 조합은 기존 설명 문단에 유지하고, 구현 범위에는 포커스 조건·텍스트 입력 예외·IndexedDB 저장·협업 서버의 운영 제한만 남겼습니다.
- 축약 문구의 필수 사실과 구 장문 재유입 방지 규칙을 콘텐츠 검증기에 추가했습니다.

## 검증

- `npm run lint`
- `npm run typecheck`
- `npm run test:portfolio`
- `npm run build`
- `git diff --check`
- 인앱 브라우저: 1440×900, 390×844에서 가로 오버플로 및 콘솔 오류 없음

## 시각적 변경

시각 자료 없음 — 현재 자동화 경로에서 PR 이미지 업로드를 지원하지 않아 동일 뷰포트의 실측값으로 비교했습니다.

| 대상 | 변경 전 | 변경 후 | 판단 포인트 |
| --- | --- | --- | --- |
| 1440px 구현 범위 | LocalMesh 9줄 / VizPort 5줄 / Mermaid 4줄 | LocalMesh 5줄 / VizPort 5줄 / Mermaid 4줄 | LocalMesh 과밀 해소 |
| 1440px 카드 높이 | 830.5px × 3 | 751.3px × 3 | 세 카드 높이 동일 |
| 390px 구현 범위 | LocalMesh 장문 | LocalMesh 6줄 / VizPort 6줄 / Mermaid 4줄 | 모바일 균형 및 가로 넘침 없음 |

## 리스크

런타임 로직이나 레이아웃 CSS는 변경하지 않았습니다. 단축키 세부 조합은 카드 설명에 남아 있고, 사실 경계는 자동 검증으로 고정했습니다.

## 판단

**Recommend** — 사용자 요청 범위 내 문구 축약이며 독립 Red Team P0~P2가 없습니다.