### PR TITLE
fix: 섹션 소개 문구 제거

### DIFF
--- a/scripts/validate-portfolio-content.mjs
+++ b/scripts/validate-portfolio-content.mjs
@@ -203,11 +203,6 @@ for (const [label, surface, approvedCopy] of [
   [
     "ProfessionalEvidenceSection.tsx",
     evidence,
-    "복잡한 기능일수록 상태와 책임부터 정리합니다.",
-  ],
-  [
-    "ProfessionalEvidenceSection.tsx",
-    evidence,
     "어떻게 판단해 구현하고 확인했는지 정리했습니다.",
   ],
   [
@@ -233,14 +228,8 @@ for (const [label, surface, approvedCopy] of [
   [
     "ProfileSection.tsx",
     profile,
-    "제품의 편집 화면부터 실행과 운영까지 다뤄 왔습니다.",
-  ],
-  [
-    "ProfileSection.tsx",
-    profile,
     "경력과 교육, 자격, 공개 특허를 한곳에 정리했습니다.",
   ],
-  ["ContactSection.tsx", contact, "프로젝트와 경력, 기술 글을 더 살펴보세요."],
   [
     "ContactSection.tsx",
     contact,
@@ -287,6 +276,18 @@ for (const [label, surface, approvedCopy] of [
     "주요 업무와 역할, 기술적 판단을 빠르게 살펴볼 수 있도록",
   ],
   ["index.html", index, "실제 환경에서 동작을 확인합니다."],
+  ["SectionHeading.tsx", sectionHeading, "title?: string"],
+  [
+    "SectionHeading.tsx",
+    sectionHeading,
+    '<h2 id={headingId} className="section-heading__eyebrow">',
+  ],
+  [
+    "ContactSection.tsx",
+    contact,
+    '<h2 id="contact-title" className="contact-section__eyebrow">',
+  ],
+  ["portfolio.css", portfolioCss, ".section-heading__body > p:only-child"],
 ]) {
   assertIncludes(surface, approvedCopy, label);
 }
@@ -297,6 +298,17 @@ for (const [label, surface, replacedCopy] of [
     hero,
     "기존 인터랙티브 장면은 별도 경험으로 보존했습니다.",
   ],
+  [
+    "ProfessionalEvidenceSection.tsx",
+    evidence,
+    "복잡한 기능일수록 상태와 책임부터 정리합니다.",
+  ],
+  [
+    "ProfileSection.tsx",
+    profile,
+    "제품의 편집 화면부터 실행과 운영까지 다뤄 왔습니다.",
+  ],
+  ["ContactSection.tsx", contact, "프로젝트와 경력, 기술 글을 더 살펴보세요."],
   ["ProfessionalEvidenceSection.tsx", evidence, "PROFESSIONAL EVIDENCE"],
   [
     "ProfessionalEvidenceSection.tsx",

--- a/src/portfolio/components/ContactSection.tsx
+++ b/src/portfolio/components/ContactSection.tsx
@@ -7,8 +7,9 @@ export function ContactSection() {
   return (
     <section className="contact-section" aria-labelledby="contact-title">
       <div>
-        <p className="contact-section__eyebrow">EXPLORE MORE</p>
-        <h2 id="contact-title">프로젝트와 경력, 기술 글을 더 살펴보세요.</h2>
+        <h2 id="contact-title" className="contact-section__eyebrow">
+          EXPLORE MORE
+        </h2>
         <p>지원용 이력서와 연락처는 채용 과정에서 별도로 공유합니다.</p>
       </div>
       <div className="contact-section__links">

--- a/src/portfolio/components/ProfessionalEvidenceSection.tsx
+++ b/src/portfolio/components/ProfessionalEvidenceSection.tsx
@@ -57,7 +57,6 @@ export function ProfessionalEvidenceSection() {
       <SectionHeading
         eyebrow="01 · SELECTED WORK"
         headingId="professional-evidence-title"
-        title="복잡한 기능일수록 상태와 책임부터 정리합니다."
         description="각 사례에서 어떤 문제를 맡았고, 어떻게 판단해 구현하고 확인했는지 정리했습니다."
       />
       <div className="evidence-list">

--- a/src/portfolio/components/ProfileSection.tsx
+++ b/src/portfolio/components/ProfileSection.tsx
@@ -77,7 +77,6 @@ export function ProfileSection() {
       <SectionHeading
         eyebrow="04 · EXPERIENCE & CREDENTIALS"
         headingId="experience-title"
-        title="제품의 편집 화면부터 실행과 운영까지 다뤄 왔습니다."
         description="지금까지의 경력과 교육, 자격, 공개 특허를 한곳에 정리했습니다."
       />
       <div className="profile-grid">

--- a/src/portfolio/components/SectionHeading.tsx
+++ b/src/portfolio/components/SectionHeading.tsx
@@ -2,7 +2,7 @@ interface SectionHeadingProps {
   description: string;
   eyebrow: string;
   headingId: string;
-  title: string;
+  title?: string;
 }
 
 export function SectionHeading({
@@ -13,9 +13,19 @@ export function SectionHeading({
 }: SectionHeadingProps) {
   return (
     <div className="section-heading">
-      <p className="section-heading__eyebrow">{eyebrow}</p>
+      {title ? (
+        <p className="section-heading__eyebrow">{eyebrow}</p>
+      ) : (
+        <h2 id={headingId} className="section-heading__eyebrow">
+          {eyebrow}
+        </h2>
+      )}
       <div className="section-heading__body">
-        <h2 id={headingId}>{title}</h2>
+        {title ? (
+          <h2 id={headingId} className="section-heading__title">
+            {title}
+          </h2>
+        ) : null}
         <p>{description}</p>
       </div>
     </div>

--- a/src/portfolio/portfolio.css
+++ b/src/portfolio/portfolio.css
@@ -602,8 +602,7 @@
   max-width: 56rem;
 }
 
-.section-heading h2,
-.contact-section h2 {
+.section-heading__title {
   margin: 0;
   color: var(--page-text);
   font-size: var(--type-section-title);
@@ -621,6 +620,14 @@
   font-size: var(--type-body);
   line-height: 1.72;
   word-break: keep-all;
+}
+
+.section-heading h2.section-heading__eyebrow {
+  padding-top: 0;
+}
+
+.section-heading__body > p:only-child {
+  margin-top: 0;
 }
 
 .evidence-list {
@@ -1201,13 +1208,6 @@
 
 .contact-section__eyebrow {
   color: color-mix(in srgb, var(--page-on-accent) 72%, transparent);
-}
-
-.contact-section h2 {
-  max-width: 42rem;
-  margin-top: 1rem;
-  color: var(--page-on-accent);
-  font-size: var(--type-section-title);
 }
 
 .contact-section > div > p:last-child {


### PR DESCRIPTION
## 목적

첫 화면에서 AI 문구처럼 보이는 섹션 소개 문장 3개를 제거하고, 문장을 없앤 뒤에도 섹션 구조와 여백이 자연스럽게 이어지도록 정리합니다.

## 원인

세 문장이 각 섹션의 실제 `h2`와 `aria-labelledby` 대상이어서 텍스트만 삭제하면 빈 제목과 끊긴 접근성 레이블, 불필요한 상단 여백이 남는 구조였습니다.

## 변경점

- Selected Work의 `복잡한 기능일수록 상태와 책임부터 정리합니다.` 제거
- Experience & Credentials의 `제품의 편집 화면부터 실행과 운영까지 다뤄 왔습니다.` 제거
- Explore More의 `프로젝트와 경력, 기술 글을 더 살펴보세요.` 제거
- 제목이 없는 섹션은 기존 영어 eyebrow를 실제 `h2`로 승격해 새 문구 없이 섹션 이름 유지
- 제목이 남아 있는 Public Builds·Technical Writing은 기존 대형 제목 경로와 스타일 유지
- compact heading의 빈 여백 제거 및 세 문장 재유입 방지 검증 추가

## 검증

- `npm run lint`
- `npm run typecheck`
- `npm run test:portfolio`
- `npm run build`
- `git diff --check`
- 인앱 브라우저 1440×900, 390×844 검증
  - 제거 문구 0건
  - 세 `aria-labelledby` 대상 존재
  - 가로 오버플로·콘솔 오류 없음
  - Public Builds·Technical Writing 제목 높이와 타이포 유지
- 독립 Red Team: P0~P2 없음

## 시각적 변경

시각 자료 없음 — 현재 자동화 경로에서 PR 이미지 바이너리 업로드를 지원하지 않아 동일 뷰포트 실측값으로 기록했습니다.

| 대상 | 변경 전 | 변경 후 | 판단 포인트 |
| --- | --- | --- | --- |
| Selected Work | 한국어 h2 130.6px + 설명 | 영어 라벨 h2 15px + 설명 상단 정렬 | 과한 소개 문구와 빈 여백 제거 |
| Experience & Credentials | 한국어 h2 130.6px + 설명 | 영어 라벨 h2 15px + 설명 상단 정렬 | 섹션 구조 유지 |
| Explore More | 한국어 h2 130.6px | EXPLORE MORE h2 15px | 링크 패널과 안내 문구 유지 |
| 390px | 기존 장문 제목 | 라벨-설명 간격 24px / 24px / 20.8px | 자연스러운 모바일 흐름 |

## 리스크

공용 `SectionHeading`의 제목 렌더링 분기가 바뀌지만, 제목이 있는 기존 두 섹션은 전용 클래스에 동일한 스타일을 적용했고 실화면에서 회귀가 없음을 확인했습니다.

## 판단

**Recommend** — 요청한 세 문장만 제거했으며 접근성·레이아웃·기존 섹션 스타일을 보존했습니다.